### PR TITLE
reset kernel to Python 3

### DIFF
--- a/3-jupyter/jupyter-intro.ipynb
+++ b/3-jupyter/jupyter-intro.ipynb
@@ -412,9 +412,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:ismb2019] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-ismb2019-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -426,7 +426,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
reset kernel to Python 3 avoid error message on Binder about missing kernel.